### PR TITLE
pysqlite3-binary fix

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,12 +3,12 @@ import tempfile
 
 
 #https://stackoverflow.com/questions/76958817/streamlit-your-system-has-an-unsupported-version-of-sqlite3-chroma-requires-sq
+# ruff: noqa: E402
 __import__('pysqlite3')
 import sys
 sys.modules['sqlite3'] = sys.modules.pop('pysqlite3')
-
-
 import chromadb
+
 import ollama
 import streamlit as st
 from chromadb.utils.embedding_functions.ollama_embedding_function import (

--- a/app.py
+++ b/app.py
@@ -1,6 +1,13 @@
 import os
 import tempfile
 
+
+#https://stackoverflow.com/questions/76958817/streamlit-your-system-has-an-unsupported-version-of-sqlite3-chroma-requires-sq
+__import__('pysqlite3')
+import sys
+sys.modules['sqlite3'] = sys.modules.pop('pysqlite3')
+
+
 import chromadb
 import ollama
 import streamlit as st

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -4,3 +4,4 @@ sentence-transformers==3.3.1 # CrossEncoder Re-ranking
 streamlit==1.40.1 # Application UI
 PyMuPDF==1.24.14 # PDF Document loader
 langchain-community==0.3.7 # Utils for text splitting
+pysqlite3-binary==0.5.4


### PR DESCRIPTION
Hi this is a fix for an issue with chromadb and sqlite version.  When running `make run`  the following error was showing up both on streamlit and on the console :

```
2024-12-05 08:14:03.865 Uncaught app exception
Traceback (most recent call last):
  File "/mnt/n0p1/bruno/work/github/yankeexe/llm-rag-with-reranker-demo/.venv/lib/python3.12/site-packages/streamlit/runtime/scriptrunner/exec_code.py", line 88, in exec_func_with_error_handling
    result = func()
             ^^^^^^
  File "/mnt/n0p1/bruno/work/github/yankeexe/llm-rag-with-reranker-demo/.venv/lib/python3.12/site-packages/streamlit/runtime/scriptrunner/script_runner.py", line 579, in code_to_exec
    exec(code, module.__dict__)
  File "/mnt/n0p1/bruno/work/github/yankeexe/llm-rag-with-reranker-demo/app.py", line 4, in <module>
    import chromadb
  File "/mnt/n0p1/bruno/work/github/yankeexe/llm-rag-with-reranker-demo/.venv/lib/python3.12/site-packages/chromadb/__init__.py", line 86, in <module>
    raise RuntimeError(
RuntimeError: Your system has an unsupported version of sqlite3. Chroma                     requires sqlite3 >= 3.35.0.
Please visit                     https://docs.trychroma.com/troubleshooting#sqlite to learn how                     to upgrade.
```

System: Debian 12 with python 3.12.7